### PR TITLE
Switch to releaser v1 to fix CI failures

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           ls
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Distributions


### PR DESCRIPTION
The failures seem to be coming from some change in releaser v2.