### PR TITLE
Fix jupyter-releaser CI check by moving hooks to `pyproject.toml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,17 +107,5 @@
             "bundled": false
         }
     }
-  },
-  "jupyter-releaser": {
-    "hooks": {
-      "before-build-npm": [
-        "python -m pip install jupyterlab~=3.1",
-        "jlpm",
-        "jlpm build:prod"
-      ],
-      "before-build-python": [
-        "jlpm clean:all"
-      ]
-    }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,7 @@ build_dir = "jupyterlab_ui_profiler/labextension"
 
 [tool.jupyter-releaser.options]
 version_cmd = "hatch version"
+
+[tool.jupyter-releaser.hooks]
+before-build-npm = ["python -m pip install jupyterlab~=3.1", "jlpm", "jlpm build:prod"]
+before-build-python = ["jlpm clean:all"]


### PR DESCRIPTION
See discussion in https://github.com/jupyter-server/jupyter_releaser/issues/474.