### PR TITLE
Do not sort reference timing array but its copy

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -764,7 +764,8 @@ function timingSummary(timing: ITimingOutcome): JSX.Element {
     <>
       <div
         title={
-          timing.reference.sort().map(Statistic.round).join(' ms\n') + ' ms'
+          [...timing.reference].sort().map(Statistic.round).join(' ms\n') +
+          ' ms'
         }
       >
         Reference: IQM:{' '}


### PR DESCRIPTION
Prevents incorrect order on first render of execution time benchmark.