### PR TITLE
Migrate to `@jupyterlab` npm namespace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install .[test]
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "@jupyterlab-benchmarks/ui-profiler.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jupyterlab/ui-profiler.*OK"
         python -m jupyterlab.browser_check
 
     - name: Package the extension
@@ -81,7 +81,7 @@ jobs:
 
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "@jupyterlab-benchmarks/ui-profiler.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jupyterlab/ui-profiler.*OK"
         python -m jupyterlab.browser_check --no-chrome-test
 
   integration-tests:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pip uninstall jupyterlab-ui-profiler
 
 In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
 command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
-folder is located. Then you can remove the symlink named `@jupyterlab-benchmarks/ui-profiler` within that folder.
+folder is located. Then you can remove the symlink named `@jupyterlab/ui-profiler` within that folder.
 
 ### Testing the extension
 

--- a/jupyterlab_ui_profiler/__init__.py
+++ b/jupyterlab_ui_profiler/__init__.py
@@ -4,7 +4,7 @@ from ._version import __version__
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": "@jupyterlab-benchmarks/ui-profiler"
+        "dest": "@jupyterlab/ui-profiler"
     }]
 
 
@@ -30,7 +30,7 @@ def _load_jupyter_server_extension(server_app):
       # Allow self-profiling in Chrome.
       "Document-Policy": "js-profiling"
     })
-    name = "@jupyterlab-benchmarks/ui-profiler"
+    name = "@jupyterlab/ui-profiler"
     server_app.log.info(f"Registered {name} server extension")
 
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@jupyterlab-benchmarks/ui-profiler",
+    "name": "@jupyterlab/ui-profiler",
     "version": "0.1.4",
     "description": "JupyterLab extension for profiling UI performance",
     "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ artifacts = ["jupyterlab_ui_profiler/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"jupyterlab_ui_profiler/labextension" = "share/jupyter/labextensions/@jupyterlab-benchmarks/ui-profiler"
-"install.json" = "share/jupyter/labextensions/@jupyterlab-benchmarks/ui-profiler/install.json"
+"jupyterlab_ui_profiler/labextension" = "share/jupyter/labextensions/@jupyterlab/ui-profiler"
+"install.json" = "share/jupyter/labextensions/@jupyterlab/ui-profiler/install.json"
 "jupyter-config/server-config" = "etc/jupyter/jupyter_server_config.d"
 "jupyter-config/nb-config" = "etc/jupyter/jupyter_notebook_config.d"
 

--- a/src/__tests__/jupyterlab-ui-profiler.spec.ts
+++ b/src/__tests__/jupyterlab-ui-profiler.spec.ts
@@ -2,7 +2,7 @@
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */
 
-describe('@jupyterlab-benchmarks/ui-profiler', () => {
+describe('@jupyterlab/ui-profiler', () => {
   it('should be tested', () => {
     expect(1 + 1).toEqual(2);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,10 @@ namespace CommandIDs {
 }
 
 /**
- * Initialization data for the @jupyterlab-benchmarks/ui-profiler extension.
+ * Initialization data for the @jupyterlab/ui-profiler extension.
  */
 const plugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab-benchmarks/ui-profiler:plugin',
+  id: '@jupyterlab/ui-profiler:plugin',
   autoStart: true,
   requires: [IFileBrowserFactory],
   optional: [ILauncher, ILayoutRestorer],

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -482,7 +482,8 @@ export function renderProfile(props: {
           typeof timing.resource === 'undefined' && timing.name === 'Profiler';
         const isOurProfilerCode =
           timing.resource &&
-          timing.resource.includes('@jupyterlab-benchmarks/ui-profiler');
+          (timing.resource.includes('@jupyterlab-benchmarks/ui-profiler') ||
+            timing.resource.includes('@jupyterlab/ui-profiler'));
         return !isNativeProfilerCall && !isOurProfilerCode;
       }
     );

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@jupyterlab-benchmarks/ui-profiler-ui-tests",
+  "name": "@jupyterlab/ui-profiler-ui-tests",
   "version": "1.0.0",
-  "description": "JupyterLab @jupyterlab-benchmarks/ui-profiler Integration Tests",
+  "description": "JupyterLab @jupyterlab/ui-profiler Integration Tests",
   "private": true,
   "scripts": {
     "start": "jupyter lab --config jupyter_server_test_config.py",


### PR DESCRIPTION
This was discussed at Wednesday meeting. This one will be easier to publish in for jupyterlab committers.

Edit: I am going to leave this one open for a day in case if anyone wants to comment.