### PR TITLE
Fix token identifier

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -69,5 +69,5 @@ export interface IUIProfiler {
  * The UIProfiler token.
  */
 export const IUIProfiler = new Token<IUIProfiler>(
-  '@jupyterlab/ui-profiler:manager'
+  '@jupyterlab/ui-profiler:plugin'
 );


### PR DESCRIPTION
Fixes #38 (the plugin which exposes the `IUIProfiler` interface is named `@jupyterlab/ui-profiler:plugin` not `@jupyterlab/ui-profiler:manager`).