### PR TITLE
Ensure the results directory is created before saving results

### DIFF
--- a/ui-tests/tests/profiler.spec.ts
+++ b/ui-tests/tests/profiler.spec.ts
@@ -19,6 +19,12 @@ test.describe('Profiler UI', () => {
     await contents.deleteDirectory('ui-profiler-results');
   });
 
+  test.afterAll(async ({ baseURL, request }) => {
+    const contents = galata.newContentsHelper(baseURL, undefined, request);
+    // clean up results
+    await contents.deleteDirectory('ui-profiler-results');
+  });
+
   test('adds launcher card', async ({ page }) => {
     const section = page.locator('.jp-Launcher-section', {
       has: page.locator(PROFILER_CARD_SELECTOR)

--- a/ui-tests/tests/profiler.spec.ts
+++ b/ui-tests/tests/profiler.spec.ts
@@ -1,9 +1,24 @@
-import { expect, test } from '@jupyterlab/galata';
+import { expect, galata, test } from '@jupyterlab/galata';
 
 const PROFILER_CARD_SELECTOR =
   '.jp-LauncherCard[title="Open JupyterLab UI Profiler"]';
 
+const START_BUTTON_SELECTOR =
+  '.up-BenchmarkLauncher-launchbar-buttons .jp-mod-accept';
+
+const REPEATS_INPUT_SELECTOR = '#up-profiler-benchmark_repeats';
+
+const REFRESH_BUTTON_SELECTOR = '[data-command="filebrowser:refresh"]';
+
+const HOME_SELECTOR = '.jp-BreadCrumbs-home';
+
 test.describe('Profiler UI', () => {
+  test.beforeEach(async ({ baseURL, request }) => {
+    const contents = galata.newContentsHelper(baseURL, undefined, request);
+    // delete directory to ensure there are no stale results
+    await contents.deleteDirectory('ui-profiler-results');
+  });
+
   test('adds launcher card', async ({ page }) => {
     const section = page.locator('.jp-Launcher-section', {
       has: page.locator(PROFILER_CARD_SELECTOR)
@@ -22,5 +37,37 @@ test.describe('Profiler UI', () => {
       has: page.locator('.up-UIProfiler')
     });
     expect(await panels.screenshot()).toMatchSnapshot('ui-profiler.png');
+  });
+
+  test('creates result even after removing results directory', async ({
+    page,
+    request,
+    baseURL
+  }) => {
+    const contents = galata.newContentsHelper(baseURL, undefined, request);
+    const handle = await page.waitForSelector(PROFILER_CARD_SELECTOR);
+    await handle.click();
+    const resultLocator = page.locator(
+      '.up-BenchmarkHistory-file >> text=execution-time_menuOpen'
+    );
+    const directoryLocator = page.locator(
+      '.jp-DirListing-item >> text="ui-profiler-results"'
+    );
+    await page.locator(HOME_SELECTOR).click();
+    await expect(directoryLocator).toHaveCount(1);
+    await expect(resultLocator).toHaveCount(0);
+    const startButton = await page.waitForSelector(START_BUTTON_SELECTOR);
+    // delete it second time after it was created
+    await contents.deleteDirectory('ui-profiler-results');
+    const refreshButton = page.locator(REFRESH_BUTTON_SELECTOR);
+    await refreshButton.click();
+    await expect(directoryLocator).toHaveCount(0);
+    const repeatsInput = await page.waitForSelector(REPEATS_INPUT_SELECTOR);
+    await repeatsInput.fill('5');
+    await startButton.click();
+    await page.waitForSelector('.up-mod-completed');
+    await expect(resultLocator).toHaveCount(1);
+    await refreshButton.click();
+    await expect(directoryLocator).toHaveCount(1);
   });
 });

--- a/ui-tests/tests/results.spec.ts
+++ b/ui-tests/tests/results.spec.ts
@@ -20,6 +20,9 @@ test.describe.configure({ mode: 'parallel' });
 test.describe('Results', () => {
   test.beforeAll(async ({ baseURL, request, tmpPath }) => {
     const contents = galata.newContentsHelper(baseURL, undefined, request);
+    // re-create directory to ensure there are no stale results
+    await contents.deleteDirectory('ui-profiler-results');
+    await contents.createDirectory('ui-profiler-results');
     for (const fileName of fileNames) {
       await contents.uploadFile(
         path.resolve(__dirname, `./ui-profiler-results/${fileName}`),


### PR DESCRIPTION
Fixes #36 by ensuring the `ui-profiler-results` directory is created before we save the result even if user deleted it in the meantime.