### PR TITLE
Use `_version.py` auto-generated by Hatchling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .ipynb_checkpoints
 *.tsbuildinfo
 jupyterlab_ui_profiler/labextension
+jupyterlab_ui_profiler/_version.py
 
 # custom
 archive/

--- a/jupyterlab_ui_profiler/_version.py
+++ b/jupyterlab_ui_profiler/_version.py
@@ -1,6 +1,0 @@
-import json
-from pathlib import Path
-
-__all__ = ["__version__"]
-
-__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ exclude = [".github", "binder"]
 "jupyter-config/server-config" = "etc/jupyter/jupyter_server_config.d"
 "jupyter-config/nb-config" = "etc/jupyter/jupyter_notebook_config.d"
 
+[tool.hatch.build.hooks.version]
+path = "jupyterlab_ui_profiler/_version.py"
+
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = ["hatch-jupyter-builder>=0.5"]
 build-function = "hatch_jupyter_builder.npm_builder"


### PR DESCRIPTION
Fixes #33. Hatchling will now auto-generate version file looking like this:

```python
# This file is auto-generated by Hatchling. As such, do not: 
#   - modify 
#   - track in version control e.g. be sure to add to .gitignore 
__version__ = VERSION = '0.1.7' 
```