### PR TITLE
Expose option types for more convenient use downstream

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -3,7 +3,7 @@ import { Statistic } from './statistics';
 import { reportTagCounts } from './utils';
 import { layoutReady } from './dramaturg';
 import benchmarkExecutionOptionsSchema from './schema/benchmark-execution.json';
-import type { ExecutionTimeBenchmarkOptions } from './types/_benchmark-execution';
+import type { ExecutionTimeBenchmarkOptions } from './types';
 import { renderTimings } from './ui';
 import {
   IBenchmark,

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,5 +138,6 @@ const interfacePlugin: JupyterFrontEndPlugin<void> = {
 };
 
 export * from './tokens';
+export * from './types';
 
 export default [plugin, scenariosPlugin, interfacePlugin];

--- a/src/jsBenchmarks.ts
+++ b/src/jsBenchmarks.ts
@@ -8,7 +8,7 @@ import { renderProfile } from './ui';
 import { IBenchmark, IScenario } from './tokens';
 
 import benchmarkProfileOptionsSchema from './schema/benchmark-profile.json';
-import type { ProfileBenchmarkOptions } from './types/_benchmark-profile';
+import type { ProfileBenchmarkOptions } from './types';
 
 interface IFunctionTiming {
   time: number;

--- a/src/scenarios.ts
+++ b/src/scenarios.ts
@@ -14,12 +14,15 @@ import {
 } from './dramaturg';
 import { IScenario, IUIProfiler } from './tokens';
 
-import type { TabScenarioOptions, Tab } from './types/_scenario-tabs';
-import type { MenuOpenScenarioOptions } from './types/_scenario-menu-open';
-import type { CompleterScenarioOptions } from './types/_scenario-completer';
-import type { SidebarsScenarioOptions } from './types/_scenario-sidebars';
-import type { ScrollScenarioOptions } from './types/_scenario-scroll';
-import type { DebuggerScenarioOptions } from './types/_scenario-debugger';
+import type { Tab } from './types/_scenario-tabs';
+import type {
+  MenuOpenScenarioOptions,
+  CompleterScenarioOptions,
+  SidebarsScenarioOptions,
+  TabScenarioOptions,
+  ScrollScenarioOptions,
+  DebuggerScenarioOptions
+} from './types';
 
 import scenarioOptionsSchema from './schema/scenario-base.json';
 import scenarioMenuOpenOptionsSchema from './schema/scenario-menu-open.json';

--- a/src/styleBenchmarks.tsx
+++ b/src/styleBenchmarks.tsx
@@ -19,10 +19,10 @@ import benchmarkRuleOptionsSchema from './schema/benchmark-rule.json';
 import benchmarkRuleGroupOptionsSchema from './schema/benchmark-rule-group.json';
 import benchmarkRuleUsageOptionsSchema from './schema/benchmark-rule-usage.json';
 
-import type { BenchmarkOptions } from './types/_benchmark-base';
-import type { StyleRuleBenchmarkOptions } from './types/_benchmark-rule';
-import type { StyleRuleGroupBenchmarkOptions } from './types/_benchmark-rule-group';
-import type { StyleRuleUsageOptions } from './types/_benchmark-rule-usage';
+import type { BenchmarkOptions } from './types';
+import type { StyleRuleBenchmarkOptions } from './types';
+import type { StyleRuleGroupBenchmarkOptions } from './types';
+import type { StyleRuleUsageOptions } from './types';
 
 interface IStylesheetResult extends ITimeMeasurement {
   content: string | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,13 @@
+export type { BenchmarkOptions } from './_benchmark-base';
+export type { StyleRuleBenchmarkOptions } from './_benchmark-rule';
+export type { StyleRuleGroupBenchmarkOptions } from './_benchmark-rule-group';
+export type { StyleRuleUsageOptions } from './_benchmark-rule-usage';
+export type { ProfileBenchmarkOptions } from './_benchmark-profile';
+export type { ExecutionTimeBenchmarkOptions } from './_benchmark-execution';
+
+export type { TabScenarioOptions } from './_scenario-tabs';
+export type { MenuOpenScenarioOptions } from './_scenario-menu-open';
+export type { CompleterScenarioOptions } from './_scenario-completer';
+export type { SidebarsScenarioOptions } from './_scenario-sidebars';
+export type { ScrollScenarioOptions } from './_scenario-scroll';
+export type { DebuggerScenarioOptions } from './_scenario-debugger';


### PR DESCRIPTION
This is because downstream needs to type arguments when calling `runBenchmark()`. imports via `lib` are already possible but not convenient.