### PR TITLE
Allow to filter sheet and rule benchmarks to only include some rules

### DIFF
--- a/src/css.ts
+++ b/src/css.ts
@@ -64,7 +64,7 @@ export async function extractSourceMap(
 
 export async function collectRules(
   styles: HTMLStyleElement[],
-  options: { skipPattern?: RegExp }
+  options: { skipPattern?: RegExp; includePattern?: RegExp }
 ): Promise<IRuleData[]> {
   let j = 0;
   const allRules: IRuleData[] = [];
@@ -85,6 +85,12 @@ export async function collectRules(
       if (
         options.skipPattern &&
         rule.selectorText.match(options.skipPattern) != null
+      ) {
+        continue;
+      }
+      if (
+        options.includePattern &&
+        rule.selectorText.match(options.includePattern) == null
       ) {
         continue;
       }

--- a/src/schema/benchmark-rule-group.json
+++ b/src/schema/benchmark-rule-group.json
@@ -30,6 +30,11 @@
       "type": "integer",
       "minimum": 0,
       "default": 5
+    },
+    "includePattern": {
+      "title": "Regular expression to filter rules to include",
+      "type": "string",
+      "default": ""
     }
   }
 }

--- a/src/schema/benchmark-rule-usage.json
+++ b/src/schema/benchmark-rule-usage.json
@@ -17,6 +17,11 @@
       "title": "Regular expression to filter out classes used for rule discovery",
       "type": "string",
       "default": "(fa-|jp-icon|Icon|lm-Widget|lm-mod-|jp-mod-|p-mod-|p-Widget)"
+    },
+    "includePattern": {
+      "title": "Regular expression to filter rules to include",
+      "type": "string",
+      "default": ""
     }
   }
 }

--- a/src/schema/benchmark-rule.json
+++ b/src/schema/benchmark-rule.json
@@ -12,6 +12,11 @@
       "title": "Regular expression to filter out rules",
       "type": "string",
       "default": "(fa-|Icon|bp3|mod-hidden)"
+    },
+    "includePattern": {
+      "title": "Regular expression to filter rules to include",
+      "type": "string",
+      "default": ""
     }
   }
 }

--- a/src/schema/benchmark-sheet.json
+++ b/src/schema/benchmark-sheet.json
@@ -1,0 +1,17 @@
+{
+  "title": "Style Sheet Benchmark Options",
+  "type": "object",
+  "properties": {
+    "repeats": {
+      "title": "Number of repeats",
+      "type": "integer",
+      "minimum": 1,
+      "default": 5
+    },
+    "includePattern": {
+      "title": "Regular expression to filter sheets to benchmark",
+      "type": "string",
+      "default": ""
+    }
+  }
+}

--- a/src/types/_benchmark-rule-group.ts
+++ b/src/types/_benchmark-rule-group.ts
@@ -10,6 +10,7 @@ export type RegularExpressionToFilterOutRules = string;
 export type BlockSizeToStartWith = number;
 export type MaximalBlockSize = number;
 export type NumberOfSheetRandomizations = number;
+export type RegularExpressionToFilterRulesToInclude = string;
 
 export interface StyleRuleGroupBenchmarkOptions {
   repeats?: NumberOfRepeats;
@@ -17,5 +18,6 @@ export interface StyleRuleGroupBenchmarkOptions {
   minBlocks?: BlockSizeToStartWith;
   maxBlocks?: MaximalBlockSize;
   sheetRandomizations?: NumberOfSheetRandomizations;
+  includePattern?: RegularExpressionToFilterRulesToInclude;
   [k: string]: any;
 }

--- a/src/types/_benchmark-rule-usage.ts
+++ b/src/types/_benchmark-rule-usage.ts
@@ -8,10 +8,12 @@
 export type NumberOfRepeats = number;
 export type RegularExpressionToFilterOutRules = string;
 export type RegularExpressionToFilterOutClassesUsedForRuleDiscovery = string;
+export type RegularExpressionToFilterRulesToInclude = string;
 
 export interface StyleRuleUsageOptions {
   repeats?: NumberOfRepeats;
   skipPattern?: RegularExpressionToFilterOutRules;
   excludeMatchPattern?: RegularExpressionToFilterOutClassesUsedForRuleDiscovery;
+  includePattern?: RegularExpressionToFilterRulesToInclude;
   [k: string]: any;
 }

--- a/src/types/_benchmark-sheet.ts
+++ b/src/types/_benchmark-sheet.ts
@@ -6,12 +6,10 @@
  */
 
 export type NumberOfRepeats = number;
-export type RegularExpressionToFilterOutRules = string;
-export type RegularExpressionToFilterRulesToInclude = string;
+export type RegularExpressionToFilterSheetsToBenchmark = string;
 
-export interface StyleRuleBenchmarkOptions {
+export interface StyleSheetBenchmarkOptions {
   repeats?: NumberOfRepeats;
-  skipPattern?: RegularExpressionToFilterOutRules;
-  includePattern?: RegularExpressionToFilterRulesToInclude;
+  includePattern?: RegularExpressionToFilterSheetsToBenchmark;
   [k: string]: any;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export type { BenchmarkOptions } from './_benchmark-base';
 export type { StyleRuleBenchmarkOptions } from './_benchmark-rule';
 export type { StyleRuleGroupBenchmarkOptions } from './_benchmark-rule-group';
 export type { StyleRuleUsageOptions } from './_benchmark-rule-usage';
+export type { StyleSheetBenchmarkOptions } from './_benchmark-sheet';
 export type { ProfileBenchmarkOptions } from './_benchmark-profile';
 export type { ExecutionTimeBenchmarkOptions } from './_benchmark-execution';
 


### PR DESCRIPTION
When only interested in specific rules or sheets, this will make run times more bearable when using large number of repeats to increase precision.